### PR TITLE
Potential fix for week2 task

### DIFF
--- a/week_2/ziegler_nichols_tuning_pid.py
+++ b/week_2/ziegler_nichols_tuning_pid.py
@@ -35,7 +35,7 @@ def simulate_with_given_pid_values(sim_, kp, joints_id, regulation_displacement=
     sim_.ResetPose()
     
     # updating the kp value for the joint we want to tune
-    kp_vec = np.array([1000]*dyn_model.getNumberofActuatedJoints())
+    kp_vec = np.array([0]*dyn_model.getNumberofActuatedJoints())
     kp_vec[joints_id] = kp
 
     kd = np.array([0]*dyn_model.getNumberofActuatedJoints())
@@ -67,7 +67,7 @@ def simulate_with_given_pid_values(sim_, kp, joints_id, regulation_displacement=
         # Ensure q_init is within the range of the amplitude
         
         # Control command
-        cmd.tau_cmd = feedback_lin_ctrl(dyn_model, q_mes, qd_mes, q_des, qd_des, kp, kd)  # Zero torque command
+        cmd.tau_cmd = feedback_lin_ctrl(dyn_model, q_mes, qd_mes, q_des, qd_des, kp_vec, kd)  # Zero torque command
         sim_.Step(cmd, "torque")  # Simulation step with torque command
 
         # Exit logic with 'q' key


### PR DESCRIPTION
It seems like a typo which leads to a weird behaviour. My reasoning is as follows:

1. The graphs with increasing kp did not look convincing. So I noticed that we're ignoring the generated arrays of kp_vec coefficients and instead just passing a single kp number, which inside the feedback_lin_ctrl() function gets turned into an array of these numbers, [see the code here](https://github.com/VModugno/simulation_and_control/blob/e3b7d0881cee1de5681ec82e19bdaffbc8981679/simulation_and_control/controllers/FeedbackLin.py#L41). 
2. When I changed kp to kp_vec on the line 70 the robot started to move chaotically and all oscillation graphs for a joint under test started to look like that with kp only ~1: 
![kp_1 1_sec_50](https://github.com/user-attachments/assets/608b3992-2cdc-4f06-b71b-009c7c9c1dda)

3. After setting kp_vec to all zeros the robot and the graphs normalized to more or less expected behaviour: 
![kp_1 2_sec_50](https://github.com/user-attachments/assets/7333fe15-4336-4d19-9a59-d80733579e5f)

Creating this PR more as a question whether it's a correct fix since during the class it was mentioned that kp_vec needs to be filled with large numbers.
